### PR TITLE
Improvements and fixes

### DIFF
--- a/config/docker.yml
+++ b/config/docker.yml
@@ -55,35 +55,13 @@ metrics:
     metric_source: lambda
   value: 100
   interval: 90s
-- name: test_summary_0
-  type: summary
+- name: test_gauge_0
+  type: gauge
   labels:
-    metric_type: summary
+    metric_type: gauge
     metric_interval: default
     instance: first
-  value: 10
-  interval: 10s
-- name: test_summary_0
-  type: summary
-  labels:
-    metric_type: summary
-    metric_interval: default
-    instance: second
-  value: 15
-  interval: 10s
-- name: test_histogram_0
-  type: histogram
-  labels:
-    metric_type: histogram
-    metric_interval: default
-    instance: first
-  value: 10
-  interval: 10s
-- name: test_histogram_0
-  type: histogram
-  labels:
-    metric_type: histogram
-    metric_interval: default
-    instance: second
-  value: 15
+  random_value:
+    min: 10
+    max: 20
   interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
 
   vmagent:
     container_name: vmagent
-    image: victoriametrics/vmagent
+    image: victoriametrics/vmagent:heads-issue-4667-0-g2f62ea390
     command:
       - "-remoteWrite.url=http://vm:8428/api/v1/write"
       - "-remoteWrite.streamAggr.keepInput=true"

--- a/grafana/dashboards/dashboard.json
+++ b/grafana/dashboards/dashboard.json
@@ -442,7 +442,7 @@
             "uid": "P4169E866C3094E38"
           },
           "editorMode": "code",
-          "expr": "histogram_quantiles(\"quantile\", 0.50, 0.99, test_histogram_0_bucket:bucket{})",
+          "expr": "histogram_quantiles(\"quantile\", 0.50, 0.99, test_gauge_0:bucket{})",
           "instant": false,
           "range": true,
           "refId": "A"
@@ -453,7 +453,7 @@
             "uid": "P4169E866C3094E38"
           },
           "editorMode": "code",
-          "expr": "histogram_quantiles(\"quantile\", 0.50 ,0.99, test_histogram_0_bucket{})",
+          "expr": "histogram_quantiles(\"quantile\", 0.50, 0.99, histogram_over_time(test_gauge_0[30s]))",
           "hide": false,
           "instant": false,
           "range": true,
@@ -464,7 +464,7 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -473,7 +473,7 @@
       },
       "id": 8,
       "panels": [],
-      "title": "Summaries",
+      "title": "Quantiles",
       "type": "row"
     },
     {
@@ -559,7 +559,8 @@
             "uid": "P4169E866C3094E38"
           },
           "editorMode": "code",
-          "expr": "test_summary_0_sum{}",
+          "expr": "sum(quantiles_over_time('quantile', 0.50, 0.99, test_gauge_0[30s]))",
+          "hide": false,
           "instant": false,
           "range": true,
           "refId": "A"
@@ -570,14 +571,14 @@
             "uid": "P4169E866C3094E38"
           },
           "editorMode": "code",
-          "expr": "test_summary_0_sum:quantiles{}",
+          "expr": "sum(test_gauge_0:quantiles[30s])",
           "hide": false,
           "instant": false,
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Summaries",
+      "title": "Gauges",
       "type": "timeseries"
     }
   ],

--- a/src/main.go
+++ b/src/main.go
@@ -21,6 +21,7 @@ func (l labels) String() string {
 		tmpSlice = append(tmpSlice, fmt.Sprintf(`%s="%s"`, k, v))
 	}
 
+	sort.Strings(tmpSlice)
 	return strings.Join(tmpSlice, ",")
 }
 

--- a/vmagent/aggregation_config.yml
+++ b/vmagent/aggregation_config.yml
@@ -1,6 +1,7 @@
 # counter, default (10s)
 - match: "{metric_type='counter',metric_interval='default'}"
   interval: 60s
+  staleness_interval: 180s
   without: [instance, metric_type, metric_interval]
   outputs: ["total", "sum_samples", "increase", "max"]
   output_relabel_configs:
@@ -9,22 +10,12 @@
       regex: "(.+):.+_(.+)"
       replacement: "$1:$2"
 
-# summary, default (10s)
-- match: "{metric_type='summary',metric_interval='default'}"
-  interval: 10s
+# gauge, default (10s)
+- match: "{metric_type='gauge',metric_interval='default'}"
+  interval: 30s
+  staleness_interval: 120s
   without: [instance, metric_type, metric_interval]
-  outputs: ["quantiles(0.50, 0.99)"]
-  output_relabel_configs:
-    - source_labels: [ __name__ ]
-      target_label: __name__
-      regex: "(.+):.+_(.+)"
-      replacement: "$1:$2"
-
-# histogram, default (10s)
-- match: "{metric_type='histogram',metric_interval='default'}"
-  interval: 10s
-  without: [instance, metric_type, metric_interval]
-  outputs: ["histogram_bucket"]
+  outputs: ["histogram_bucket", "quantiles(0.50, 0.99)"]
   output_relabel_configs:
     - source_labels: [ __name__ ]
       target_label: __name__


### PR DESCRIPTION
Some improvements:
- Added metric type `gauge`.
- Added ability to generate random values.

Fixed issues with stream aggregation:
- Fixed metrics rendering: added sorting, as some identical counters were rendered (and pushed) as different metrics
- vmagent image in docker-compose updated to include changes to issue https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4667 and staleness_interval property added to aggregation config
- Histogram queries in grafana-dashboard fixed and rewritten with gauge-metric because it has to use gauge-metric instead of histogram bucket metric
- Quantiles queries in grafana-dashboard fixed and rewritten with gauge-metric because it has to use gauge-metric instead of counter (summary_sum)